### PR TITLE
Allow Configuration of Feeding Size

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,37 +1,40 @@
 {
   "pluginAlias": "PetSafeSmartFeed",
   "pluginType": "platform",
+  "singular": true,
   "schema": {
     "type": "object",
     "properties": {
       "token": {
         "title": "Auth Token",
         "type": "string",
-        "placeholder": "Token",
         "required": true,
         "description": "Token obtained by running `npx -p homebridge-petsafe-smart-feed petsafe-auth-cli`"
       },
-      "amount": {
-        "title": "Feeding Amount",
-        "type": "integer",
-        "placeholder": 0,
-        "minimum": 0,
-        "required": false,
-        "description": "Feeding size in 1/8 cups. Set to 0 to feed the previous feeding amount."
+      "feeders": {
+        "title": "Feeders",
+        "type": "array",
+        "minLength": 0,
+        "items": {
+          "title": "Feeder",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Feeder ID",
+              "type": "integer",
+              "required": true,
+              "description": "See output from plugin startup for feeder IDs."
+            },
+            "amount": {
+              "title": "Feeding Amount",
+              "type": "integer",
+              "placeholder": 0,
+              "minimum": 0,
+              "description": "Feeding size in 1/8 cups. Set to 0 to feed the previous feeding amount."
+            }
+          }
+        }
       }
-    },
-    "required": [
-      "token",
-      "password"
-    ]
-  },
-  "layout": [
-    {
-      "type": "fieldset",
-      "items": [
-        "token",
-        "amount"
-      ]
     }
-  ]
+  }
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -10,6 +10,14 @@
         "placeholder": "Token",
         "required": true,
         "description": "Token obtained by running `npx -p homebridge-petsafe-smart-feed petsafe-auth-cli`"
+      },
+      "amount": {
+        "title": "Feeding Amount",
+        "type": "integer",
+        "placeholder": 0,
+        "minimum": 0,
+        "required": false,
+        "description": "Feeding size in 1/8 cups. Set to 0 to feed the previous feeding amount."
       }
     },
     "required": [
@@ -21,7 +29,8 @@
     {
       "type": "fieldset",
       "items": [
-        "token"
+        "token",
+        "amount"
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "displayName": "Homebridge PetSafe Smart Feed",
   "name": "homebridge-petsafe-smart-feed",
   "version": "1.1.6",
   "description": "Homebridge plugin for PetSafe Smart Feed",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -31,7 +31,11 @@ export class SmartFeedAccessory {
         if (value && !this.onCurrentlyFeeding.getValue()) {
           try {
             this.onCurrentlyFeeding.next(true)
-            await feeder.repeatLastFeed()
+            if(this.accessory.context.amount > 0) {
+              await feeder.feed({ amount: this.accessory.context.amount })
+            } else {
+              await feeder.repeatLastFeed()
+            }
             logInfo(`Done Feeding ${feeder.name}`)
             await delay(2 * 60 * 1000)
           } catch (e) {

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -14,10 +14,15 @@ import {
   Service as ServiceClass,
 } from 'homebridge'
 
+export interface FeederConfig {
+  id: number,
+  amount: number
+}
+
 export class SmartFeedAccessory {
   onCurrentlyFeeding = new BehaviorSubject(false)
 
-  constructor(private feeder: SmartFeed, private accessory: PlatformAccessory) {
+  constructor(private feeder: SmartFeed, private accessory: PlatformAccessory, private feederConfig: FeederConfig = {id: 0, amount: 0}) {
     const { Service, Characteristic } = hap,
       feedService = this.getService(Service.Switch),
       feedCharacteristic = feedService.getCharacteristic(Characteristic.On),
@@ -31,8 +36,8 @@ export class SmartFeedAccessory {
         if (value && !this.onCurrentlyFeeding.getValue()) {
           try {
             this.onCurrentlyFeeding.next(true)
-            if(this.accessory.context.amount > 0) {
-              await feeder.feed({ amount: this.accessory.context.amount })
+            if(this.feederConfig.amount > 0) {
+              await feeder.feed({ amount: this.feederConfig.amount })
             } else {
               await feeder.repeatLastFeed()
             }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -63,7 +63,7 @@ export class PetSafeSmartFeedPlatform implements DynamicPlatformPlugin {
       activeAccessoryIds: string[] = [],
       debugPrefix = debug ? 'TEST ' : ''
 
-    this.log.info(`Configuring ${feeders.length} PetSafe Smart Feeders`)
+    this.log.info(`Configuring ${feeders.length} PetSafe Smart Feeder(s)`)
 
     feeders.forEach((feeder) => {
       const uuid = hap.uuid.generate(debugPrefix + feeder.id),
@@ -82,6 +82,8 @@ export class PetSafeSmartFeedPlatform implements DynamicPlatformPlugin {
         },
         homebridgeAccessory =
           this.homebridgeAccessories[uuid] || createHomebridgeAccessory()
+
+      homebridgeAccessory.context = this.config
 
       new SmartFeedAccessory(feeder, homebridgeAccessory)
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,7 +1,7 @@
 import { ApiConfig, SmartFeedApi } from './api'
 import { hap, platformName, pluginName } from './hap'
 import { useLogger } from './util'
-import { SmartFeedAccessory } from './accessory'
+import { SmartFeedAccessory, FeederConfig } from './accessory'
 import {
   API,
   DynamicPlatformPlugin,
@@ -63,9 +63,10 @@ export class PetSafeSmartFeedPlatform implements DynamicPlatformPlugin {
       activeAccessoryIds: string[] = [],
       debugPrefix = debug ? 'TEST ' : ''
 
-    this.log.info(`Configuring ${feeders.length} PetSafe Smart Feeder(s)`)
+    this.log.info(`Configuring ${feeders.length} PetSafe Smart Feeder(s):`)
 
     feeders.forEach((feeder) => {
+      this.log.info(` - ${feeder.name}: ${feeder.id}`)
       const uuid = hap.uuid.generate(debugPrefix + feeder.id),
         displayName = debugPrefix + feeder.name,
         createHomebridgeAccessory = () => {
@@ -83,9 +84,9 @@ export class PetSafeSmartFeedPlatform implements DynamicPlatformPlugin {
         homebridgeAccessory =
           this.homebridgeAccessories[uuid] || createHomebridgeAccessory()
 
-      homebridgeAccessory.context = this.config
+      const feederConfig = this.config.feeders ? this.config.feeders.filter((config: FeederConfig) => config.id === feeder.id)[0] : undefined
 
-      new SmartFeedAccessory(feeder, homebridgeAccessory)
+      new SmartFeedAccessory(feeder, homebridgeAccessory, feederConfig)
 
       this.homebridgeAccessories[uuid] = homebridgeAccessory
       activeAccessoryIds.push(uuid)

--- a/src/smart-feed.ts
+++ b/src/smart-feed.ts
@@ -72,6 +72,7 @@ export class SmartFeed {
     amount = 1,
     slowFeed = this.initialInfo.settings.slow_feed,
   } = {}) {
+    logInfo(`Feeding ${this.name} ${amount}/8 Cups ${slowFeed ? 'Slowly' : ''}`)
     await this.restClient.request({
       method: 'POST',
       url: this.feederPath('meals'),
@@ -104,7 +105,6 @@ export class SmartFeed {
     const lastFeeding = await this.getLastFeedingMessage(),
       amount = lastFeeding?.payload?.amount || 1
 
-    logInfo(`Feeding ${this.name} ${amount}/8 Cups`)
     await this.feed({ amount })
   }
 


### PR DESCRIPTION
My last feeding amount often resets to 1/8 cup for some reason, so I added the ability to configure the feeding size instead. This allows me to be sure of the amount that hitting the switch will feed.

If the 'amount' config option is 0 or not set, it will continue the previous behavior of using the previous amount fed.