### PR TITLE
Changes to battery levels, based on official app.

### DIFF
--- a/src/smart-feed.ts
+++ b/src/smart-feed.ts
@@ -9,7 +9,9 @@ import {
 } from 'rxjs/operators'
 import { logError, logInfo } from './util'
 
-const minVoltage = 26000,
+// t = voltage / 32767 * 3.6 * 2
+// t >= 5.9: 3/3, t >= 5.5: 2/3, t >= 5: 1/3, t >= 0: 0/3
+const minVoltage = 22755,
   maxVoltage = 29100
 
 function getBatteryLevel(info: FeederInfo) {


### PR DESCRIPTION
Fixes #13 

I just changed min and max voltage based on the code from the Android app. I used `t` of 6 for max and 5 for min, since those seemed to be the most reasonable choices based on their code (full above 5.9, dead below 5), but I'm open to tweaks if you think other values are more appropriate.