### PR TITLE
Correct warning about SerialNumber on Homebridge 1.3

### DIFF
--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -83,7 +83,7 @@ export class SmartFeedAccessory {
       .updateValue(feeder.state.product_name || 'Smart Feed')
     accessoryInfoService
       .getCharacteristic(Characteristic.SerialNumber)
-      .updateValue(feeder.state.serial || feeder.id)
+      .updateValue(feeder.id.toString())
 
     this.registerCharacteristic(
       accessoryInfoService.getCharacteristic(Characteristic.FirmwareRevision),


### PR DESCRIPTION
Currently on startup this plugin generates this warning on Homebridge 1.3: `This plugin generated a warning from the characteristic 'Serial Number': characteristic was supplied illegal value: number instead of string. Supplying illegal values will throw errors in the future! See https://git.io/JtMGR for more info.`

This would fix that. The reason I dropped `feeder.state.serial`, was because it was defined as type null, so would never have come in to play anyways?